### PR TITLE
Fix defect in loading of data where it exists in Firebase but not Elasticsearch

### DIFF
--- a/lib/NestedPathMonitor.js
+++ b/lib/NestedPathMonitor.js
@@ -58,7 +58,7 @@ NestedPathMonitor.prototype._childUpsert = function(key, data) {
     // Because we have to re-index the parent doc, we want to include
     // any existing nested elements.
     var refreshed = rsp._source[self.parentField];
-    var allIds = refreshed.map( function(c) { 
+    var allIds = (refreshed || []).map( function(c) { 
       return c[self.childIdField];
     });
     // Overwrite the returned result set with any changed contents

--- a/lib/NestedPathMonitor.js
+++ b/lib/NestedPathMonitor.js
@@ -58,7 +58,11 @@ NestedPathMonitor.prototype._childUpsert = function(key, data) {
     // Because we have to re-index the parent doc, we want to include
     // any existing nested elements.
     var refreshed = rsp._source[self.parentField];
-    var allIds = (refreshed || []).map( function(c) { 
+    if (!refreshed) {
+      logger.warn('Document "' + key + '" lacks parent field "' + self.parentField  + '"!');
+      refreshed = [];
+    }
+    var allIds = (refreshed).map( function(c) { 
       return c[self.childIdField];
     });
     // Overwrite the returned result set with any changed contents


### PR DESCRIPTION
In cases where data is added to Firebase but the corresponding object key doesn't yet exist in Elasticsearch, Flue fails with the following error because it assumes an undefined key is an array:

```
22:40:31.775Z ERROR flue:
  Could not index wecites: TypeError: Cannot call method 'map' of undefined
      at /Users/yrl/casetext/cases-on-fire/node_modules/flue/lib/NestedPathMonitor.js:70:28
      at tryCatch1 (/Users/yrl/casetext/cases-on-fire/node_modules/flue/node_modules/elasticsearch/node_modules/bluebird/js/main/util.js:43:21)
      at Promise$_callHandler [as _callHandler] (/Users/yrl/casetext/cases-on-fire/node_modules/flue/node_modules/elasticsearch/node_modules/bluebird/js/main/promise.js:627:13)
      at Promise$_settlePromiseFromHandler [as _settlePromiseFromHandler] (/Users/yrl/casetext/cases-on-fire/node_modules/flue/node_modules/elasticsearch/node_modules/bluebird/js/main/promise.js:641:18)
      at Promise$_settlePromiseAt [as _settlePromiseAt] (/Users/yrl/casetext/cases-on-fire/node_modules/flue/node_modules/elasticsearch/node_modules/bluebird/js/main/promise.js:804:14)
      at Promise$_settlePromises [as _settlePromises] (/Users/yrl/casetext/cases-on-fire/node_modules/flue/node_modules/elasticsearch/node_modules/bluebird/js/main/promise.js:938:14)
      at Async$_consumeFunctionBuffer [as _consumeFunctionBuffer] (/Users/yrl/casetext/cases-on-fire/node_modules/flue/node_modules/elasticsearch/node_modules/bluebird/js/main/async.js:75:12)
      at Async$consumeFunctionBuffer (/Users/yrl/casetext/cases-on-fire/node_modules/flue/node_modules/elasticsearch/node_modules/bluebird/js/main/async.js:38:14)
      at process._tickDomainCallback (node.js:486:13)
```

This pull request fixes that defect.
